### PR TITLE
MSS-515: Support edition override

### DIFF
--- a/json/navigation-conf/international.json
+++ b/json/navigation-conf/international.json
@@ -208,6 +208,7 @@
     {
       "title": "Lifestyle",
       "path": "lifeandstyle",
+      "edition": "uk",
       "sections": [
         {
           "title": "Food",

--- a/json/navigation-conf/international.json
+++ b/json/navigation-conf/international.json
@@ -208,7 +208,7 @@
     {
       "title": "Lifestyle",
       "path": "lifeandstyle",
-      "edition": "uk",
+      "editionOverride": "uk",
       "sections": [
         {
           "title": "Food",

--- a/src/main/scala/com/gu/navigation/model/NavigationSection.scala
+++ b/src/main/scala/com/gu/navigation/model/NavigationSection.scala
@@ -9,7 +9,8 @@ case class NavigationSection(
   title: String,
   path: String,
   mobileOverride: Option[String] = None,
-  sections: Option[List[NavigationSection]] = None
+  sections: Option[List[NavigationSection]] = None,
+  editionOverride: Option[String] = None
 )
 
 object NavigationSection  {
@@ -18,14 +19,16 @@ object NavigationSection  {
     (__ \ "title").read[String] and
       (__ \ "path").read[String] and
       (__ \ "mobileOverride").readNullable[String] and
-      (__ \ "sections").lazyReadNullable(implicitly[Reads[List[NavigationSection]]])
+      (__ \ "sections").lazyReadNullable(implicitly[Reads[List[NavigationSection]]]) and
+      (__ \ "editionOverride").readNullable[String]
     )(NavigationSection.apply _)
 
   implicit val navigationSectionWrites: Writes[NavigationSection] = (
     (__ \ "title").write[String] and
       (__ \ "path").write[String] and
       (__ \ "mobileOverride").writeNullable[String] and
-      (__ \ "sections").lazyWriteNullable(implicitly[Writes[List[NavigationSection]]])
+      (__ \ "sections").lazyWriteNullable(implicitly[Writes[List[NavigationSection]]]) and
+      (__ \ "editionOverride").writeNullable[String]
     )(unlift(NavigationSection.unapply _))
 
   implicit lazy val disNavigationSectionFormat: Format[NavigationSection] = Format(navigationSectionReads, navigationSectionWrites)

--- a/src/test/scala/com/gu/navigation/NavigationProviderTest.scala
+++ b/src/test/scala/com/gu/navigation/NavigationProviderTest.scala
@@ -16,6 +16,7 @@ class NavigationProviderTest extends Specification {
       |      "editionalised": true,
       |      "sections" : [
       |        { "title": "world", "path": "world",
+  |              "editionOverride": "au",
       |          "sections" : [
       |            { "title": "world", "path": "world" },
       |            { "title": "europe", "path": "world/europe-news" }
@@ -71,7 +72,7 @@ class NavigationProviderTest extends Specification {
       NavigationSection(title = "", path = "",
         sections = Some(
           List(
-            NavigationSection(title = "world",path = "world",
+            NavigationSection(title = "world",path = "world",editionOverride = Some("au") ,
               sections = Some(List(NavigationSection(title = "world", path = "world"),
                                    NavigationSection(title = "europe", path = "world/europe-news")
                               )


### PR DESCRIPTION
Lifestyle international front should point to Lifestyle uk.
By adding an edition override option it should be possible to configure this behaviour.