### PR TITLE
MSS-1229: Update AUS podcast navigation

### DIFF
--- a/json/navigation-conf/au.json
+++ b/json/navigation-conf/au.json
@@ -262,6 +262,16 @@
       "path": "podcasts",
       "sections": [
         {
+          "title": "Full Story",
+          "path": "australia-news/series/full-story",
+          "sections": []
+        },
+        {
+          "title": "Politics",
+          "path": "australia-news/series/australian-politics-live",
+          "sections": []
+        },
+        {
           "title": "Today in Focus",
           "path": "news/series/todayinfocus",
           "sections": []
@@ -274,21 +284,6 @@
         {
           "title": "Audio Long Reads",
           "path": "news/series/the-audio-long-read",
-          "sections": []
-        },
-        {
-          "title": "Politics",
-          "path": "australia-news/series/australian-politics-live",
-          "sections": []
-        },
-        {
-          "title": "Behind the Lines",
-          "path": "australia-news/series/behind-the-lines-podcast",
-          "sections": []
-        },
-        {
-          "title": "Token",
-          "path": "society/series/token",
           "sections": []
         },
         {
@@ -309,16 +304,6 @@
         {
           "title": "The Story",
           "path": "news/series/the-story",
-          "sections": []
-        },
-        {
-          "title": "Culture",
-          "path": "artanddesign/series/guardian-australia-culture-podcast",
-          "sections": []
-        },
-        {
-          "title": "Global development",
-          "path": "global-development/series/global-development-podcast",
           "sections": []
         }
       ]


### PR DESCRIPTION
This add's the new flagship podcast "[Full Story](https://www.theguardian.com/australia-news/series/full-story)" to the podcast navigation in the Australian edition of the app. 

It also removes some outdated subjects, and changes the order to be as following:

Full Story
Politics
Today in Focus
Football 
Audio Long Reads
Science
Books
Tech
The Story

<img src="https://user-images.githubusercontent.com/19835654/68214844-1c09cf80-ffd6-11e9-8113-d8c3d2d35d8b.PNG" width="300px" />
