### PR TITLE
Remove US election from nav

### DIFF
--- a/json/navigation-conf/us.json
+++ b/json/navigation-conf/us.json
@@ -11,11 +11,6 @@
       "sections": []
     },
     {
-      "title": "Elections 2020",
-      "path": "us-news/us-elections-2020",
-      "sections": []
-    },
-    {
       "title": "World",
       "path": "world",
       "sections": [


### PR DESCRIPTION
## What does this change?
Removes US election from the nav as it is not needed anymore, as requested by Editorial.