### PR TITLE
Remove redundant Euro 2020 section from football nav

### DIFF
--- a/json/navigation-conf/international.json
+++ b/json/navigation-conf/international.json
@@ -139,12 +139,7 @@
     {
       "title": "Football",
       "path": "football",
-      "sections": [
-        {
-          "title": "Euro 2020",
-          "path": "football/euro-2020"
-        }
-      ]
+      "sections": []
     },
     {
       "title": "Opinion",

--- a/json/navigation-conf/uk.json
+++ b/json/navigation-conf/uk.json
@@ -144,12 +144,7 @@
     {
       "title": "Football",
       "path": "football",
-      "sections": [
-        {
-          "title": "Euro 2020",
-          "path": "football/euro-2020"
-        }
-      ]
+      "sections": []
     },
     {
       "title": "Opinion",


### PR DESCRIPTION
## What does this change?
Remove redundant Euro 2020 section from football nav, this change actually happens in MAPI