### PR TITLE
LIVE-2820 - Remove euro 2020 and add tokyo 2020 to sport

### DIFF
--- a/json/navigation-conf/au.json
+++ b/json/navigation-conf/au.json
@@ -54,6 +54,10 @@
       "path": "au/sport",
       "sections": [
         {
+          "title": "Tokyo 2020",
+          "path": "sport/olympic-games-2020"
+        },
+        {
           "title": "Australia sport",
           "path": "sport/australia-sport"
         },

--- a/json/navigation-conf/international.json
+++ b/json/navigation-conf/international.json
@@ -87,8 +87,8 @@
       "path": "sport",
       "sections": [
         {
-          "title": "Euro 2020",
-          "path": "football/euro-2020"
+          "title": "Tokyo 2020",
+          "path": "sport/olympic-games-2020"
         },
         {
           "title": "Football",
@@ -139,12 +139,8 @@
     {
       "title": "Football",
       "path": "football",
-      "sections": [
-        {
-          "title": "Euro 2020",
-          "path": "football/euro-2020"
-        }
-      ]
+
+      "sections": []
     },
     {
       "title": "Opinion",

--- a/json/navigation-conf/uk.json
+++ b/json/navigation-conf/uk.json
@@ -92,8 +92,8 @@
       "path": "uk/sport",
       "sections": [
         {
-          "title": "Euro 2020",
-          "path": "football/euro-2020"
+          "title": "Tokyo 2020",
+          "path": "sport/olympic-games-2020"
         },
         {
           "title": "Football",
@@ -144,12 +144,7 @@
     {
       "title": "Football",
       "path": "football",
-      "sections": [
-        {
-          "title": "Euro 2020",
-          "path": "football/euro-2020"
-        }
-      ]
+      "sections": []
     },
     {
       "title": "Opinion",

--- a/json/navigation-conf/us.json
+++ b/json/navigation-conf/us.json
@@ -58,6 +58,10 @@
       "path": "us/sport",
       "sections": [
         {
+          "title": "Tokyo 2020",
+          "path": "sport/olympic-games-2020"
+        },
+        {
           "title": "Soccer",
           "path": "football",
           "mobileOverride": "section-list"


### PR DESCRIPTION
## What does this change?
This PR removes `Euro 2020` from sport and football navigations and adds `Tokyo 2020` to the sport navigation for all editions.