### PR TITLE
LIVE-2988: Add Tokyo 2020 Paralympics to sport nav in all editions

### DIFF
--- a/json/navigation-conf/au.json
+++ b/json/navigation-conf/au.json
@@ -54,6 +54,10 @@
       "path": "au/sport",
       "sections": [
         {
+          "title":"Tokyo 2020 Paralympics",
+          "path": "sport/paralympic-games-2020"
+        },
+        {
           "title": "Australia sport",
           "path": "sport/australia-sport"
         },

--- a/json/navigation-conf/international.json
+++ b/json/navigation-conf/international.json
@@ -87,6 +87,10 @@
       "path": "sport",
       "sections": [
         {
+          "title":"Tokyo 2020 Paralympics",
+          "path": "sport/paralympic-games-2020"
+        },
+        {
           "title": "Football",
           "path": "football"
         },

--- a/json/navigation-conf/uk.json
+++ b/json/navigation-conf/uk.json
@@ -92,6 +92,10 @@
       "path": "uk/sport",
       "sections": [
         {
+          "title":"Tokyo 2020 Paralympics",
+          "path": "sport/paralympic-games-2020"
+        },
+        {
           "title": "Football",
           "path": "football"
         },

--- a/json/navigation-conf/us.json
+++ b/json/navigation-conf/us.json
@@ -58,6 +58,10 @@
       "path": "us/sport",
       "sections": [
         {
+          "title":"Tokyo 2020 Paralympics",
+          "path": "sport/paralympic-games-2020"
+        },
+        {
           "title": "Soccer",
           "path": "football",
           "mobileOverride": "section-list"


### PR DESCRIPTION
## What does this change?
Add Tokyo 2020 Paralympics to sport nav in all editions