### PR TITLE
LIVE-3032 - remove paralympics from sport nav

### DIFF
--- a/json/navigation-conf/au.json
+++ b/json/navigation-conf/au.json
@@ -54,10 +54,6 @@
       "path": "au/sport",
       "sections": [
         {
-          "title":"Tokyo 2020 Paralympics",
-          "path": "sport/tokyo-paralympic-games-2020"
-        },
-        {
           "title": "Australia sport",
           "path": "sport/australia-sport"
         },

--- a/json/navigation-conf/international.json
+++ b/json/navigation-conf/international.json
@@ -87,10 +87,6 @@
       "path": "sport",
       "sections": [
         {
-          "title":"Tokyo 2020 Paralympics",
-          "path": "sport/tokyo-paralympic-games-2020"
-        },
-        {
           "title": "Football",
           "path": "football"
         },

--- a/json/navigation-conf/uk.json
+++ b/json/navigation-conf/uk.json
@@ -92,10 +92,6 @@
       "path": "uk/sport",
       "sections": [
         {
-          "title":"Tokyo 2020 Paralympics",
-          "path": "sport/tokyo-paralympic-games-2020"
-        },
-        {
           "title": "Football",
           "path": "football"
         },

--- a/json/navigation-conf/us.json
+++ b/json/navigation-conf/us.json
@@ -58,10 +58,6 @@
       "path": "us/sport",
       "sections": [
         {
-          "title":"Tokyo 2020 Paralympics",
-          "path": "sport/tokyo-paralympic-games-2020"
-        },
-        {
           "title": "Soccer",
           "path": "football",
           "mobileOverride": "section-list"


### PR DESCRIPTION
## What does this change?
This PR removes paralympics from all editions' sport nav

## How to test
Check the app after deploying