### PR TITLE
LIVE-3636 Change "Green Light" series to "Fight to Vote" series

### DIFF
--- a/json/navigation-conf/us.json
+++ b/json/navigation-conf/us.json
@@ -134,8 +134,8 @@
       ]
     },
     {
-      "title": "Green Light",
-      "path": "environment/series/green-light",
+      "title": "Fight to Vote",
+      "path": "us-news/series/the-fight-to-vote",
       "sections": []
     },
     {


### PR DESCRIPTION
## What does this change?

As per request from Editorials, we changed the "Green Light" series to "Fight to Vote" series on the menu for US edition. 

## How to test

I made the same change to the `us.json` for CODE and checked if the menu was updated correctly, the caption was correct and the link went to the correct page.

## How can we measure success?

The menu was updated accordingly.

## Have we considered potential risks?

Yes.  

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#screen-readers)
- [ ] [Navigable with keyboard](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#keyboard-navigation)
- [ ] [Colour contrast passed](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#use-of-colour)
