### PR TITLE
LIVE-3793: Add Politics Weekly UK, America and Weekend to all navs

### DIFF
--- a/json/navigation-conf/au.json
+++ b/json/navigation-conf/au.json
@@ -292,8 +292,23 @@
           "sections": []
         },
         {
+          "title": "Politics Weekly UK",
+          "path": "politics/series/politicsweekly",
+          "sections": []
+        },
+        {
+          "title": "Politics Weekly America",
+          "path": "politics/series/politics-weekly-america",
+          "sections": []
+        },
+        {
           "title": "Today in Focus",
           "path": "news/series/todayinfocus",
+          "sections": []
+        },
+        {
+          "title": "Weekend",
+          "path": "lifeandstyle/series/weekend",
           "sections": []
         },
         {

--- a/json/navigation-conf/international.json
+++ b/json/navigation-conf/international.json
@@ -376,8 +376,18 @@
           "sections": []
         },
         {
-          "title": "UK Politics",
+          "title": "Politics Weekly UK",
           "path": "politics/series/politicsweekly",
+          "sections": []
+        },
+        {
+          "title": "Politics Weekly America",
+          "path": "politics/series/politics-weekly-america",
+          "sections": []
+        },
+        {
+          "title": "Weekend",
+          "path": "lifeandstyle/series/weekend",
           "sections": []
         },
         {

--- a/json/navigation-conf/uk.json
+++ b/json/navigation-conf/uk.json
@@ -388,8 +388,18 @@
           "sections": []
         },
         {
-          "title": "Politics Weekly",
+          "title": "Politics Weekly UK",
           "path": "politics/series/politicsweekly",
+          "sections": []
+        },
+        {
+          "title": "Politics Weekly America",
+          "path": "politics/series/politics-weekly-america",
+          "sections": []
+        },
+        {
+          "title": "Weekend",
+          "path": "lifeandstyle/series/weekend",
           "sections": []
         },
         {

--- a/json/navigation-conf/us.json
+++ b/json/navigation-conf/us.json
@@ -283,8 +283,18 @@
           "sections": []
         },
         {
-          "title": "UK Politics",
+          "title": "Politics Weekly America",
+          "path": "politics/series/politics-weekly-america",
+          "sections": []
+        },
+        {
+          "title": "Politics Weekly UK",
           "path": "politics/series/politicsweekly",
+          "sections": []
+        },
+        {
+          "title": "Weekend",
+          "path": "lifeandstyle/series/weekend",
           "sections": []
         },
         {


### PR DESCRIPTION
## What does this change?
Adds Politics Weekly UK, America and Weekend to all navs as requested by editorial
