### PR TITLE
Add F1 to US/sports

### DIFF
--- a/json/navigation-conf/us.json
+++ b/json/navigation-conf/us.json
@@ -82,6 +82,10 @@
         {
           "title": "NHL",
           "path": "sport/nhl"
+        },
+        {
+          "title": "F1",
+          "path": "sport/formulaone"
         }
       ]
     },


### PR DESCRIPTION
Editorials requested to add "F1" tag page to the end of the drop down menu for US/sport.