### PR TITLE
Revert "Add women's euros to football"

### DIFF
--- a/json/navigation-conf/international.json
+++ b/json/navigation-conf/international.json
@@ -135,12 +135,8 @@
     {
       "title": "Football",
       "path": "football",
-      "sections": [
-        {
-          "title": "Women's Euro 2022",
-          "path": "football/women-s-euro-2022"
-        }
-      ]
+
+      "sections": []
     },
     {
       "title": "Opinion",

--- a/json/navigation-conf/uk.json
+++ b/json/navigation-conf/uk.json
@@ -140,12 +140,7 @@
     {
       "title": "Football",
       "path": "football",
-      "sections": [
-        {
-          "title": "Women's Euro 2022",
-          "path": "football/women-s-euro-2022"
-        }
-      ]
+      "sections": []
     },
     {
       "title": "Opinion",


### PR DESCRIPTION
Reverts guardian/cross-platform-navigation#39

We added this as a quick test to understand how to mutate football subnav links - the change has to be made in mapi though (NavigationHooks), not here