### PR TITLE
Add obituaries fronts to the nav

### DIFF
--- a/json/navigation-conf/au.json
+++ b/json/navigation-conf/au.json
@@ -340,6 +340,11 @@
       ]
     },
     {
+      "title": "Obituaries",
+      "path": "obituaries",
+      "sections": []
+    },    
+    {
       "title": "Support us",
       "path": "membership",
       "sections": []

--- a/json/navigation-conf/international.json
+++ b/json/navigation-conf/international.json
@@ -348,6 +348,11 @@
       "sections": []
     },
     {
+      "title": "Obituaries",
+      "path": "obituaries",
+      "sections": []
+    },    
+    {
       "title": "Video",
       "path": "video",
       "sections": []

--- a/json/navigation-conf/uk.json
+++ b/json/navigation-conf/uk.json
@@ -360,6 +360,11 @@
       "sections": []
     },
     {
+      "title": "Obituaries",
+      "path": "obituaries",
+      "sections": []
+    },    
+    {
       "title": "Video",
       "path": "video",
       "sections": []

--- a/json/navigation-conf/us.json
+++ b/json/navigation-conf/us.json
@@ -259,6 +259,11 @@
       "sections": []
     },
     {
+      "title": "Obituaries",
+      "path": "obituaries",
+      "sections": []
+    },    
+    {
       "title": "Video",
       "path": "video",
       "sections": []


### PR DESCRIPTION
## What does this change?

Per editorial's request, we add the fronts `obituaries` to the navigation menu.

## How to test

Uploaded the JSON to S3 for CODE and check the response from [navigation](https://mobile-origin.mobile-aws.code.dev-guardianapis.com/uk/navigation)

