### PR TITLE
Add Europe navigation cross platform navigation conf. file

### DIFF
--- a/json/navigation-conf/europe.json
+++ b/json/navigation-conf/europe.json
@@ -1,0 +1,447 @@
+{
+  "pillars": [
+    {
+      "title": "UK",
+      "path": "uk-news",
+      "sections": [
+        {
+          "title": "Politics",
+          "path": "politics"
+        },
+        {
+          "title": "Education",
+          "path": "education"
+        },
+        {
+          "title": "Media",
+          "path": "media"
+        },
+        {
+          "title": "Society",
+          "path": "society"
+        },
+        {
+          "title": "Law",
+          "path": "law",
+          "mobileOverride": "section-list"
+        },
+        {
+          "title": "Scotland",
+          "path": "uk/scotland"
+        },
+        {
+          "title": "Wales",
+          "path": "uk/wales"
+        },
+        {
+          "title": "Northern Ireland",
+          "path": "uk/northernireland"
+        }
+      ]
+    },
+    {
+      "title": "Coronavirus",
+      "path": "world/coronavirus-outbreak",
+      "sections": []
+    },
+    {
+      "title": "World",
+      "path": "world",
+      "sections": [
+        {
+          "title": "Europe",
+          "path": "world/europe-news"
+        },
+        {
+          "title": "US",
+          "path": "us-news"
+        },
+        {
+          "title": "Americas",
+          "path": "world/americas"
+        },
+        {
+          "title": "Asia",
+          "path": "world/asia"
+        },
+        {
+          "title": "Australia",
+          "path": "australia-news"
+        },
+        {
+          "title": "Africa",
+          "path": "world/africa"
+        },
+        {
+          "title": "Middle East",
+          "path": "world/middleeast"
+        },
+        {
+          "title": "Development",
+          "path": "global-development"
+        }
+      ]
+    },
+    {
+      "title": "Sport",
+      "path": "sport",
+      "sections": [
+        {
+          "title": "Football",
+          "path": "football"
+        },
+        {
+          "title": "Cricket",
+          "path": "sport/cricket"
+        },
+        {
+          "title": "Rugby union",
+          "path": "sport/rugby-union"
+        },
+        {
+          "title": "F1",
+          "path": "sport/formulaone"
+        },
+        {
+          "title": "Tennis",
+          "path": "sport/tennis"
+        },
+        {
+          "title": "Golf",
+          "path": "sport/golf"
+        },
+        {
+          "title": "Cycling",
+          "path": "sport/cycling"
+        },
+        {
+          "title": "Boxing",
+          "path": "sport/boxing"
+        },
+        {
+          "title": "Racing",
+          "path": "sport/horse-racing"
+        },
+        {
+          "title": "Rugby league",
+          "path": "sport/rugbyleague"
+        },
+        {
+          "title": "US sports",
+          "path": "sport/us-sport"
+        }
+      ]
+    },
+    {
+      "title": "Football",
+      "path": "football",
+
+      "sections": []
+    },
+    {
+      "title": "Opinion",
+      "path": "commentisfree",
+      "sections": []
+    },
+    {
+      "title": "Culture",
+      "path": "culture",
+      "sections": [
+        {
+          "title": "Film",
+          "path": "film"
+        },
+        {
+          "title": "TV & radio",
+          "path": "tv-and-radio"
+        },
+        {
+          "title": "Music",
+          "path": "music"
+        },
+        {
+          "title": "Games",
+          "path": "games"
+        },
+        {
+          "title": "Books",
+          "path": "books"
+        },
+        {
+          "title": "Art & design",
+          "path": "artanddesign"
+        },
+        {
+          "title": "Stage",
+          "path": "stage"
+        },
+        {
+          "title": "Classical",
+          "path": "music/classical-music-and-opera"
+        }
+      ]
+    },
+    {
+      "title": "Environment",
+      "path": "environment",
+      "sections": [
+        {
+          "title": "Climate crisis",
+          "path": "environment/climate-crisis"
+        },
+        {
+          "title": "Wildlife",
+          "path": "environment/wildlife"
+        },
+        {
+          "title": "Energy",
+          "path": "environment/energy"
+        },
+        {
+          "title": "Pollution",
+          "path": "environment/pollution"
+        }
+      ]
+    },
+    {
+      "title": "Climate crisis",
+      "path": "environment/climate-crisis",
+      "sections": []
+    },
+    {
+      "title": "Business",
+      "path": "business",
+      "sections": [
+        {
+          "title": "Economics",
+          "path": "business/economics"
+        },
+        {
+          "title": "Banking",
+          "path": "business/banking"
+        },
+        {
+          "title": "Retail",
+          "path": "business/retail"
+        },
+        {
+          "title": "Markets",
+          "path": "business/stock-markets"
+        },
+        {
+          "title": "Eurozone",
+          "path": "business/eurozone"
+        }
+      ]
+    },
+    {
+      "title": "Lifestyle",
+      "path": "lifeandstyle",
+      "editionOverride": "uk",
+      "sections": [
+        {
+          "title": "Food",
+          "path": "food"
+        },
+        {
+          "title": "Health & fitness",
+          "path": "lifeandstyle/health-and-wellbeing"
+        },
+        {
+          "title": "Love & sex",
+          "path": "lifeandstyle/love-and-sex"
+        },
+        {
+          "title": "Beauty",
+          "path": "fashion/beauty"
+        },
+        {
+          "title": "Cars",
+          "path": "technology/motoring"
+        },
+        {
+          "title": "Women",
+          "path": "lifeandstyle/women"
+        },
+        {
+          "title": "Home & garden",
+          "path": "lifeandstyle/home-and-garden"
+        }
+      ]
+    },
+    {
+      "title": "Fashion",
+      "path": "fashion",
+      "sections": []
+    },
+    {
+      "title": "Tech",
+      "path": "technology",
+      "sections": []
+    },
+    {
+      "title": "Travel",
+      "path": "travel",
+      "sections": [
+        {
+          "title": "UK",
+          "path": "travel/uk"
+        },
+        {
+          "title": "Europe",
+          "path": "travel/europe"
+        },
+        {
+          "title": "US",
+          "path": "travel/usa"
+        },
+        {
+          "title": "Skiing",
+          "path": "travel/skiing"
+        }
+      ]
+    },
+    {
+      "title": "Money",
+      "path": "money",
+      "sections": [
+        {
+          "title": "Property",
+          "path": "money/property"
+        },
+        {
+          "title": "Savings",
+          "path": "money/savings"
+        },
+        {
+          "title": "Pensions",
+          "path": "money/pensions"
+        },
+        {
+          "title": "Borrowing",
+          "path": "money/debt"
+        },
+        {
+          "title": "Careers",
+          "path": "money/work-and-careers"
+        }
+      ]
+    },
+    {
+      "title": "Science",
+      "path": "science",
+      "sections": []
+    },
+    {
+      "title": "Education",
+      "path": "education",
+      "sections": [
+        {
+          "title": "Students",
+          "path": "education/students"
+        }
+      ]
+    },
+    {
+      "title": "Media",
+      "path": "media",
+      "sections": []
+    },
+    {
+      "title": "Obituaries",
+      "path": "obituaries",
+      "sections": []
+    },    
+    {
+      "title": "Video",
+      "path": "video",
+      "sections": []
+    },
+    {
+      "title": "Podcasts",
+      "path": "podcasts",
+      "sections": [
+        {
+          "title": "Today in Focus",
+          "path": "news/series/todayinfocus",
+          "sections": []
+        },
+        {
+          "title": "Football",
+          "path": "football/series/footballweekly",
+          "sections": []
+        },
+        {
+          "title": "Long Reads",
+          "path": "news/series/the-audio-long-read",
+          "sections": []
+        },
+        {
+          "title": "Politics Weekly UK",
+          "path": "politics/series/politicsweekly",
+          "sections": []
+        },
+        {
+          "title": "Politics Weekly America",
+          "path": "politics/series/politics-weekly-america",
+          "sections": []
+        },
+        {
+          "title": "Weekend",
+          "path": "lifeandstyle/series/weekend",
+          "sections": []
+        },
+        {
+          "title": "Aus Politics",
+          "path": "australia-news/series/politics-live-with-katharine-murphy",
+          "sections": []
+        },
+        {
+          "title": "Books",
+          "path": "books/series/books",
+          "sections": []
+        },
+        {
+          "title": "Science",
+          "path": "science/series/science",
+          "sections": []
+        },
+        {
+          "title": "Tech",
+          "path": "technology/series/chips-with-everything",
+          "sections": []
+        },
+        {
+          "title": "The Story",
+          "path": "news/series/the-story",
+          "sections": []
+        },
+        {
+          "title": "Global Development",
+          "path": "global-development/series/global-development-podcast",
+          "sections": []
+        },
+        {
+          "title": "Politics",
+          "path": "us-news/series/politics-for-humans",
+          "sections": []
+        }
+      ]
+    },
+    {
+      "title": "The Observer",
+      "path": "observer",
+      "sections": []
+    },
+    {
+      "title": "Support us",
+      "path": "membership",
+      "sections": []
+    },
+    {
+      "title": "Corrections",
+      "path": "theguardian/series/corrections-and-clarifications",
+      "sections": []
+    }
+  ]
+}


### PR DESCRIPTION
## What does this change?

This adds the navigation configuration file for the new Europe edition. 

At the moment, this is an exact copy of the International conf. file as we do not have Europe-specific navigation yet. This should be revisited closer to launch date. 

We need this in order to get the Europe edition into [MAPI](https://github.com/guardian/mobile-apps-api/tree/add-europe-edition-in-mapi) 

## How to test

TBC

## How can we measure success?

`europe/navigation` should work in MAPI

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
