### PR TITLE
Add golf to US sports section

### DIFF
--- a/json/navigation-conf/us.json
+++ b/json/navigation-conf/us.json
@@ -86,6 +86,10 @@
         {
           "title": "F1",
           "path": "sport/formulaone"
+        },
+        {
+          "title": "Golf",
+          "path": "sport/golf"
         }
       ]
     },


### PR DESCRIPTION
## What does this change?

The US sports desk have asked for the Golf [page](https://www.theguardian.com/sport/golf) to be added to sports menu dropdown in the US edition of the app.

## How to test

After updating the json file I manually uploaded it to the S3 bucket and redeployed mobile-fronts to CODE. After that the golf page can be seen in the menu dropdown of the US edition of the debug app:

<img src="https://user-images.githubusercontent.com/45561419/233589632-f0a65b3e-fbe6-46f8-95a4-8cf2cf87feb3.jpg" width="300px" />

Following the link takes you to the expected page:

<img src="https://user-images.githubusercontent.com/45561419/233590175-63990644-350f-4f2f-bcb3-776a5808f053.jpg" width="300px" />

