### PR TITLE
Change "Fight to Vote" to "Fight for Democracy" on US nav

### DIFF
--- a/json/navigation-conf/us.json
+++ b/json/navigation-conf/us.json
@@ -142,8 +142,8 @@
       ]
     },
     {
-      "title": "Fight to Vote",
-      "path": "us-news/series/the-fight-to-vote",
+      "title": "Fight for Democracy",
+      "path": "us-news/series/the-fight-for-democracy",
       "sections": []
     },
     {


### PR DESCRIPTION
## What does this change?

As per request from Editorial, we changed the "Fight to Vote" series to "Fight for Democracy" on the menu for US edition.

## How to test

The same change was made to the us.json for CODE, and we checked that the menu was updated correctly, the caption was correct and the link went to the correct page.

## How can we measure success?

The menu was updated accordingly.

## Images

| Navigation | Series |
| --- | --- |
| ![Simulator Screen Shot - iPhone 14 - 2023-05-10 at 11 19 13](https://github.com/guardian/cross-platform-navigation/assets/55602675/0e3b2f8c-6f18-4b3d-b69f-e2ca8b84578d) | ![Simulator Screen Shot - iPhone 14 - 2023-05-10 at 11 19 19](https://github.com/guardian/cross-platform-navigation/assets/55602675/9c0e8f76-15f6-46bb-a1c1-8037bb1e29de) |


## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
