### PR TITLE
Updated sbt To 1.9.0

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.16
+sbt.version=1.9.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,8 +7,3 @@ addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.6.1")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "0.5.1")
-
-
-
-addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")
-


### PR DESCRIPTION
- Removed sbt-dependency-graph because it's now included in sbt from 1.4.
