### PR TITLE
Fix sbt release: add required `publishTo` field

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -41,6 +41,7 @@ riffRaffUploadManifestBucket := Option("riffraff-builds")
 riffRaffManifestProjectName := s"Mobile::${name.value}"
 riffRaffArtifactResources ++= listJsonFilesInJsonDir
 
+publishTo := sonatypePublishToBundle.value
 publishMavenStyle := true
 Test / publishArtifact := false
 pomIncludeRepository := {_ => false}

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "1.1-SNAPSHOT"
+ThisBuild / version := "1.2-SNAPSHOT"


### PR DESCRIPTION
The sbt-sonatype plugin wants this: https://github.com/xerial/sbt-sonatype#buildsbt
