### PR TITLE
Remove coronavirus from UK, International and Europe editions

### DIFF
--- a/json/navigation-conf/europe.json
+++ b/json/navigation-conf/europe.json
@@ -40,11 +40,6 @@
       ]
     },
     {
-      "title": "Coronavirus",
-      "path": "world/coronavirus-outbreak",
-      "sections": []
-    },
-    {
       "title": "World",
       "path": "world",
       "sections": [

--- a/json/navigation-conf/international.json
+++ b/json/navigation-conf/international.json
@@ -40,11 +40,6 @@
       ]
     },
     {
-      "title": "Coronavirus",
-      "path": "world/coronavirus-outbreak",
-      "sections": []
-    },
-    {
       "title": "World",
       "path": "world",
       "sections": [

--- a/json/navigation-conf/uk.json
+++ b/json/navigation-conf/uk.json
@@ -40,11 +40,6 @@
       ]
     },
     {
-      "title": "Coronavirus",
-      "path": "world/coronavirus-outbreak",
-      "sections": []
-    },
-    {
       "title": "Politics",
       "path": "politics",
       "sections": []


### PR DESCRIPTION
We have been asked by editorial to remove coronavirus from navigation.

## What does this change?

Removes Coronavirus from UK and International editions (currently on prod) and Europe edition (currently not in prod).

## How to test

The same change was made to the uk.json, international.json in CODE, and the menu was updated correctly.

## Images

| Before | After |
| --- | --- |
| ![Simulator Screen Shot - iPhone 14 - 2023-07-18 at 18 13 11](https://github.com/guardian/cross-platform-navigation/assets/55602675/875f2925-2f87-4367-88f5-d60fc23d94d7) | ![Simulator Screen Shot - iPhone 14 - 2023-07-18 at 18 11 32](https://github.com/guardian/cross-platform-navigation/assets/55602675/7fdcf0ce-70a4-4fec-8af3-4eeca04d7e8d) |

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
