### PR TITLE
LIVE-5503 Add the new editionalized us/soccer front to US nav

### DIFF
--- a/json/navigation-conf/us.json
+++ b/json/navigation-conf/us.json
@@ -59,8 +59,8 @@
       "sections": [
         {
           "title": "Soccer",
-          "path": "football",
-          "mobileOverride": "section-list"
+          "path": "us/soccer",
+          "mobileOverride": "section-front"
         },
         {
           "title": "MLS",

--- a/json/navigation-conf/us.json
+++ b/json/navigation-conf/us.json
@@ -95,7 +95,7 @@
     },
     {
       "title": "Soccer",
-      "path": "football",
+      "path": "us/soccer",
       "sections": []
     },
     {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

The editorials are going to launch a new editionalized `us/soccer` front.  They want the existing `Soccer` item under `Sport` on US nav to go to this new front.

This PR is to replace the link of `Soccer` menu to this `us/soccer` front.

This PR should not be merged until the new US soccer front has been launched (planned on 4-Aug).

## How to test
The modified JSON file was uploaded to the `CODE` location of S3 bucket. 

The front has not been launched so we have checked the response from the CODE `navigation` endpoint only.

| Before | After |
| --- | --- |
| <img src="https://github.com/guardian/cross-platform-navigation/assets/89925410/5cf58eae-66f1-416a-a092-915fef109ccc" width="300px" /> | <img src="https://github.com/guardian/cross-platform-navigation/assets/89925410/838c577d-1dee-4c88-adec-2d6325d1d20d" width="300px" /> |


<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

