### PR TITLE
Ensure football competitions show up under US soccer front

### DIFF
--- a/json/navigation-conf/us.json
+++ b/json/navigation-conf/us.json
@@ -96,6 +96,7 @@
     {
       "title": "Soccer",
       "path": "us/soccer",
+      "mobileOverride": "section-front",
       "sections": []
     },
     {


### PR DESCRIPTION
## What does this change?

Football tables and competitions aren't showing up on the US edition of the nav but these nav elements are added dynamically in MAPI. We should parse the new US soccer front as a section front. Currently it defaults to a tag list but by providing the mobile override value here to ensure it's parsed correctly.

## How to test

I tested in conjunction with the [corresponding](https://github.com/guardian/mobile-apps-api/pull/2656) MAPI PR.