### PR TITLE
Migrate riff-raff upload to GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ on:
     branches:
       - main
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   ci:
     runs-on: ubuntu-latest
@@ -31,6 +35,11 @@ jobs:
         with:
           paths: "test-results/**/TEST-*.xml"
         if: always()
+
+      - uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-region: eu-west-1
+          role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
 
       - name: Upload to riff-raff
         uses: guardian/actions-riff-raff@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,21 +10,34 @@ on:
       - main
 
 jobs:
-  test:
+  ci:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
       - name: Setup JDK
         uses: actions/setup-java@v3
         with:
           distribution: corretto
           java-version: 11
           cache: sbt
-      - name: Build and Test
+
+      - name: Test
         run: sbt -v +test
+
       - name: Test Summary
         uses: test-summary/action@v2
         with:
           paths: "test-results/**/TEST-*.xml"
         if: always()
+
+      - name: Upload to riff-raff
+        uses: guardian/actions-riff-raff@v2
+        with:
+          projectName: Mobile::cross-platform-navigation
+          buildNumberOffset: 196
+          configPath: riff-raff.yaml
+          contentDirectories: |
+            json:
+              - json/

--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,7 @@ libraryDependencies ++= Seq(
 
 Test / unmanagedResourceDirectories += baseDirectory.value / "json"
 
-enablePlugins(RiffRaffArtifact, BuildInfoPlugin)
+enablePlugins(BuildInfoPlugin)
 
 def listJsonFiles(file: File) : List[File] = {
   if(file.isDirectory) {
@@ -36,12 +36,6 @@ def listJsonFilesInJsonDir: List[(File, String)] = {
     file => file -> jsonDir.relativize(file.getAbsoluteFile.toPath).toString
   }
 }
-
-riffRaffPackageType := file(".nope")
-riffRaffUploadArtifactBucket := Option("riffraff-artifact")
-riffRaffUploadManifestBucket := Option("riffraff-builds")
-riffRaffManifestProjectName := s"Mobile::${name.value}"
-riffRaffArtifactResources ++= listJsonFilesInJsonDir
 
 publishTo := sonatypePublishToBundle.value
 publishMavenStyle := true

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,3 @@
-addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.18")
-
 addSbtPlugin("com.github.sbt" % "sbt-release" % "1.1.0")
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.11.0")


### PR DESCRIPTION
## What does this change?

This extends a pre-existing CI workflow to include uploading artifacts to riff-raff. As a result I've also removed the sbt-riffraff-artifact plugin.

There is only 1 deployment type specified for this project, an [aws-s3](https://riffraff.gutools.co.uk/docs/magenta-lib/types#awss3) deployment type (on deploy, we simply upload the navigation json to an s3 bucket in the mobile account).

## How to test

There is no CODE deployment setup for this project. To test I did the following:
- Validated the CI workflow was [successful](https://github.com/guardian/cross-platform-navigation/actions/runs/5974012196/job/16207363375)
- Confirmed in the deploy tools riff raff artifacts bucket that, for the successful workflow, a corresponding set of artifacts existed, including the navigation json. Note that the json exists in the same directory hierarchy as previous versions:

| Last Team City | First GitHub action |
| ------- | ------- |
| <img width="500px" alt="Screenshot 2023-08-25 at 10 57 40" src="https://github.com/guardian/cross-platform-navigation/assets/45561419/f1e34675-aab1-4d65-aba4-4defeb4e91b0"> | <img width="500px" alt="Screenshot 2023-08-25 at 10 55 05" src="https://github.com/guardian/cross-platform-navigation/assets/45561419/a31db938-c348-42c7-94ad-b607f88ece93"> |

Given there's no riff raff deployment for CODE, there is a risk that the PROD deploy could fail (I haven't been able to test this part) but I think this is mitigated by:
- the deployment only uploads files to s3, and we can see the expected files already in the riff raff artifacts bucket.
- if the deployment to PROD fails, and updated s3 files aren't updated, there is no impact on production users (I will fix forward).
- if the deployment using the github action artifacts continues to fail, and we need to deploy urgent/new nav changes, then I can un-pause the team city project.
