### PR TITLE
Remove chips with everything, brexit means and small changes from podcast subnav menu

### DIFF
--- a/json/navigation-conf/uk.json
+++ b/json/navigation-conf/uk.json
@@ -404,23 +404,8 @@
           "sections": []
         },
         {
-          "title": "Chips with Everything",
-          "path": "technology/series/chips-with-everything",
-          "sections": []
-        },
-        {
           "title": "Australian Politics",
           "path": "australia-news/series/australian-politics-live",
-          "sections": []
-        },
-        {
-          "title": "Small Changes",
-          "path": "global-development/series/global-development-podcast",
-          "sections": []
-        },
-        {
-          "title": "Brexit means...",
-          "path": "politics/series/brexit-means",
           "sections": []
         },
         {

--- a/json/navigation-conf/uk.json
+++ b/json/navigation-conf/uk.json
@@ -379,6 +379,11 @@
           "sections": []
         },
         {
+          "title": "Comfort Eating",
+          "path": "lifeandstyle/series/comforteatingwithgracedent",
+          "sections": []
+        },
+        {
           "title": "Audio Long Reads",
           "path": "news/series/the-audio-long-read",
           "sections": []
@@ -394,6 +399,11 @@
           "sections": []
         },
         {
+          "title": "Pop Culture",
+          "path": "society/series/pop-culture-with-chante-joseph",
+          "sections": []
+        },
+        {
           "title": "Weekend",
           "path": "lifeandstyle/series/weekend",
           "sections": []
@@ -406,11 +416,6 @@
         {
           "title": "Australian Politics",
           "path": "australia-news/series/australian-politics-live",
-          "sections": []
-        },
-        {
-          "title": "Neuroscientist Explains",
-          "path": "science/series/a-neuroscientist-explains-podcast",
           "sections": []
         }
       ]


### PR DESCRIPTION
## What does this change?

 This PR removes chips with everything, small changes and brexit means from the podcast subnav menu on the UK edition following a request from Central Production.

## Testing

 Updated the json in the CODE folder in s3, reployed mobile-fronts, checked on the debug app. If you'd like to do this yourself I've added some testing instructions to the readme of this repo. 

## Images

| Before | After |
| --- | --- | 
| <img src="https://github.com/guardian/cross-platform-navigation/assets/102960825/b96ca74f-5413-4756-93d1-15b39bad0863" width="300px" /> | <img src="https://github.com/guardian/cross-platform-navigation/assets/102960825/ff054f90-44ac-453d-aedd-e2b7f66ec79e" width="300px" /> | 
