### PR TITLE
Adopt GHA-Scala-Library-Release-Workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,12 @@
+name: Release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  release:
+    uses: guardian/gha-scala-library-release-workflow/.github/workflows/reusable-release.yml@main
+    permissions: { contents: write, pull-requests: write }
+    secrets:
+      SONATYPE_PASSWORD: ${{ secrets.AUTOMATED_MAVEN_RELEASE_SONATYPE_PASSWORD }}
+      PGP_PRIVATE_KEY: ${{ secrets.AUTOMATED_MAVEN_RELEASE_PGP_SECRET }}

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,5 @@
 import sbtrelease.ReleaseStateTransformations._
+import sbtversionpolicy.withsbtrelease.ReleaseVersion
 
 name:="cross-platform-navigation"
 
@@ -19,51 +20,13 @@ Test / unmanagedResourceDirectories += baseDirectory.value / "json"
 
 enablePlugins(BuildInfoPlugin)
 
-def listJsonFiles(file: File) : List[File] = {
-  if(file.isDirectory) {
-    file.listFiles().toList.flatMap(listJsonFiles)
-  } else {
-    List(file)
-  }
-}
-
-def listJsonFilesInJsonDir: List[(File, String)] = {
-
-  val jsonFilesDir = file("json")
-  val jsonDir = jsonFilesDir.getAbsoluteFile.toPath.getParent
-
-  listJsonFiles(jsonFilesDir).map {
-    file => file -> jsonDir.relativize(file.getAbsoluteFile.toPath).toString
-  }
-}
-
-publishTo := sonatypePublishToBundle.value
-publishMavenStyle := true
-Test / publishArtifact := false
-pomIncludeRepository := {_ => false}
 description := "Provides scala representation of the navigation menus for the www.theguardian.com and guardian apps"
 
-pomExtra in Global := {
-  <url>https://github.com/guardian/cross-platform-navigation</url>
-    <developers>
-      <developer>
-        <id>@guardian</id>
-        <name>The guardian</name>
-        <url>https://github.com/guardian</url>
-      </developer>
-    </developers>
-}
-
-
-//PgpPublis
 organization := "com.gu"
-licenses := Seq("Apache v2" -> url("http://www.apache.org/licenses/LICENSE-2.0.html"))
-scmInfo := Some(ScmInfo(
-  url("https://github.com/guardian/cross-platform-navigation"),
-  "scm:git:git@github.com:guardian/cross-platform-navigation.git"
-))
+licenses := Seq(License.Apache2)
 scalacOptions ++= Seq("-deprecation", "-unchecked", "-release:11")
 releaseCrossBuild := true
+releaseVersion := ReleaseVersion.fromAggregatedAssessedCompatibilityWithLatestRelease().value
 releaseProcess := Seq(
   checkSnapshotDependencies,
   inquireVersions,
@@ -72,11 +35,8 @@ releaseProcess := Seq(
   setReleaseVersion,
   commitReleaseVersion,
   tagRelease,
-  releaseStepCommandAndRemaining("+publishSigned"),
-  releaseStepCommand("sonatypeBundleRelease"),
   setNextVersion,
-  commitNextVersion,
-  pushChanges
+  commitNextVersion
 )
 
 Test/testOptions += Tests.Argument(

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.0
+sbt.version=1.9.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,8 +1,8 @@
-addSbtPlugin("com.github.sbt" % "sbt-release" % "1.1.0")
-
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.11.0")
 
-addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.2.1")
+addSbtPlugin("com.github.sbt" % "sbt-release" % "1.1.0")
 
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.21")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.10.0")
+
+addSbtPlugin("ch.epfl.scala" % "sbt-version-policy" % "3.2.0")
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "1.3-SNAPSHOT"
+ThisBuild / version := "1.3.0-SNAPSHOT"


### PR DESCRIPTION
[`gha-scala-library-release-workflow`](https://github.com/guardian/gha-scala-library-release-workflow) gives us an automated way to publish releases of this library without needing individual Sonatype credentials for each developer!

The configuration changes are all described in [the docs for `gha-scala-library-release-workflow`](https://github.com/guardian/gha-scala-library-release-workflow/blob/main/docs/configuration.md).

We've also granted access to the release credentials through https://github.com/guardian/github-secret-access/pull/34.

See also the list of Guardian projects that have adopted this workflow so far: https://github.com/guardian/gha-scala-library-release-workflow/issues/20
