### PR TITLE
LIVE-6235 Add US election 2024 to nav menu in US edition

### DIFF
--- a/json/navigation-conf/us.json
+++ b/json/navigation-conf/us.json
@@ -6,6 +6,11 @@
       "sections": []
     },
     {
+      "title": "US elections 2024",
+      "path": "us-news/us-elections-2024",
+      "sections": []
+    },
+    {
       "title": "Politics",
       "path": "us-news/us-politics",
       "sections": []

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -9,4 +9,5 @@ deployments:
       publicReadAcl: false
       prefixPackage: false
       prefixStack: false
-      bucket: mobile-navigation-dist
+      bucketSsmLookup: true
+      bucketSsmKey: /account/services/artifact.bucket.nav


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

As per request from Central Production, this PR adds the item **US election 2024** to the nav menu for US edition.  It links to the front **us-news/us-elections-2024**

> On apps on US edition could we arrange for [US elections 2024](https://www.theguardian.com/us-news/us-elections-2024) be added beneath US and above Politics (so in second position down). No need to remove Politics there.

In addition, the riffraff configuration has also been changed to avoid having the bucket name directly.  As recommended by DevX quite a while ago, the bucket name was provided via a SSM parameter name instead.

## How to test

The navigation menu JSON was tested on CODE.  Screenshots have been captured.

|Menu|Go to|
|---|---|
|<img width="360px" src="https://github.com/guardian/cross-platform-navigation/assets/89925410/c8570daa-5762-414f-9564-1f98bf4085c8" /> | <img width="360px" src="https://github.com/guardian/cross-platform-navigation/assets/89925410/4f0858a5-1183-418b-9dc2-de65fd178412" />
