### PR TITLE
LIVE-6231 Add live events to nav for UK, EU, International editions

### DIFF
--- a/json/navigation-conf/europe.json
+++ b/json/navigation-conf/europe.json
@@ -424,6 +424,11 @@
       ]
     },
     {
+      "title": "Live events",
+      "path": "guardian-live-events",
+      "sections": []
+    },    
+    {
       "title": "The Observer",
       "path": "observer",
       "sections": []

--- a/json/navigation-conf/international.json
+++ b/json/navigation-conf/international.json
@@ -424,6 +424,11 @@
       ]
     },
     {
+      "title": "Live events",
+      "path": "guardian-live-events",
+      "sections": []
+    },    
+    {
       "title": "The Observer",
       "path": "observer",
       "sections": []

--- a/json/navigation-conf/uk.json
+++ b/json/navigation-conf/uk.json
@@ -421,6 +421,11 @@
       ]
     },
     {
+      "title": "Live events",
+      "path": "guardian-live-events",
+      "sections": []
+    },
+    {
       "title": "The Observer",
       "path": "observer",
       "sections": []


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This PR adds the *Live events* to the nav menu of the app on UK, Europe and International editions, as per editorial request.

## Images

|UK|Europe|International|
|---|---|---|
|<img width="320px" src="https://github.com/guardian/cross-platform-navigation/assets/89925410/0d609d56-c4ff-42ba-84bc-bf2c29d95410" />|<img width="320px" src="https://github.com/guardian/cross-platform-navigation/assets/89925410/79f6f57e-a543-43a9-a157-756ef4b1d01e" />|<img width="320px" src="https://github.com/guardian/cross-platform-navigation/assets/89925410/be5b0e16-2795-434a-97a5-d995635381ca" />