### PR TITLE
LIVE-6444 Add Donald Trump trials to us nav

### DIFF
--- a/json/navigation-conf/us.json
+++ b/json/navigation-conf/us.json
@@ -11,6 +11,11 @@
       "sections": []
     },
     {
+      "title": "Donald Trump trials",
+      "path": "us-news/donald-trump-trials",
+      "sections": []
+    },    
+    {
       "title": "Politics",
       "path": "us-news/us-politics",
       "sections": []


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

As per editorial request, this PR adds the "Donal Trump trials" item to the navigation menu on US edition.

|Before|After|
|---|---|
|<img src="https://github.com/guardian/cross-platform-navigation/assets/89925410/21dcb5d6-d875-4f5e-ae61-cd6805f332e6" width="320px" />|<img src="https://github.com/guardian/cross-platform-navigation/assets/89925410/10867f06-2063-48fb-a4b2-973af7df4083" width="320px" />|