### PR TITLE
Fix sustainable business tag

### DIFF
--- a/json/navigation-conf/us.json
+++ b/json/navigation-conf/us.json
@@ -211,7 +211,7 @@
         },
         {
           "title": "Sustainable business",
-          "path": "sustainable-business"
+          "path": "sustainable-business/sustainable-business"
         },
         {
           "title": "Diversity & equality",

--- a/json/navigation-conf/us.json
+++ b/json/navigation-conf/us.json
@@ -211,7 +211,7 @@
         },
         {
           "title": "Sustainable business",
-          "path": "uk/sustainable-business"
+          "path": "sustainable-business"
         },
         {
           "title": "Diversity & equality",


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This changes the tag path for `Sustainable Business` from `uk/sustainable-business` to `sustainable-business/sustainable-business`

This is because the tag `uk/sustainable-business` doesn't exist and the navigation link returns an error

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
