### PR TITLE
Update obituaries link

### DIFF
--- a/json/navigation-conf/europe.json
+++ b/json/navigation-conf/europe.json
@@ -344,7 +344,7 @@
     },
     {
       "title": "Obituaries",
-      "path": "obituaries",
+      "path": "tone/obituaries",
       "sections": []
     },    
     {

--- a/json/navigation-conf/international.json
+++ b/json/navigation-conf/international.json
@@ -344,7 +344,7 @@
     },
     {
       "title": "Obituaries",
-      "path": "obituaries",
+      "path": "tone/obituaries",
       "sections": []
     },    
     {

--- a/json/navigation-conf/uk.json
+++ b/json/navigation-conf/uk.json
@@ -356,7 +356,7 @@
     },
     {
       "title": "Obituaries",
-      "path": "obituaries",
+      "path": "tone/obituaries",
       "sections": []
     },    
     {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
As per editorial request, update the Obituaries path from 
https://www.theguardian.com/obituaries
to
https://www.theguardian.com/tone/obituaries
for UK, Europe and International
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
Tested on CODE and checked navigating to Obituaries in the editions link to the correct page (currently broken on PROD)
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

