### PR TITLE
Add Euro 2024

### DIFF
--- a/json/navigation-conf/au.json
+++ b/json/navigation-conf/au.json
@@ -99,7 +99,12 @@
     {
       "title": "Football",
       "path": "football",
-      "sections": []
+      "sections": [
+        {
+        "title": "Euro 2024",
+        "path": "football/euro-2024"
+      }
+    ]
     },
     {
       "title": "Tech",

--- a/json/navigation-conf/europe.json
+++ b/json/navigation-conf/europe.json
@@ -131,7 +131,12 @@
       "title": "Football",
       "path": "football",
 
-      "sections": []
+      "sections": [
+        {
+          "title": "Euro 2024",
+          "path": "football/euro-2024"
+        }
+      ]
     },
     {
       "title": "Opinion",

--- a/json/navigation-conf/international.json
+++ b/json/navigation-conf/international.json
@@ -131,7 +131,12 @@
       "title": "Football",
       "path": "football",
 
-      "sections": []
+      "sections": [
+        {
+          "title": "Euro 2024",
+          "path": "football/euro-2024"
+        }
+      ]
     },
     {
       "title": "Opinion",

--- a/json/navigation-conf/uk.json
+++ b/json/navigation-conf/uk.json
@@ -135,7 +135,12 @@
     {
       "title": "Football",
       "path": "football",
-      "sections": []
+      "sections": [
+        {
+          "title": "Euro 2024",
+          "path": "football/euro-2024"
+        }
+      ]
     },
     {
       "title": "Opinion",

--- a/json/navigation-conf/us.json
+++ b/json/navigation-conf/us.json
@@ -107,7 +107,12 @@
       "title": "Soccer",
       "path": "us/soccer",
       "mobileOverride": "section-front",
-      "sections": []
+      "sections": [
+        {
+          "title": "Euro 2024",
+          "path": "football/euro-2024"
+        }
+      ]
     },
     {
       "title": "Tech",


### PR DESCRIPTION
add "Euro 2024" to the Football navigation across all editions

requirements
- should navigate to https://www.theguardian.com/football/euro-2024
- should go in first place on the nav.