### PR TITLE
Add Euro 2024 to Sport nav

### DIFF
--- a/json/navigation-conf/au.json
+++ b/json/navigation-conf/au.json
@@ -58,6 +58,10 @@
           "path": "sport/australia-sport"
         },
         {
+          "title": "Euro 2024",
+          "path": "football/euro-2024"
+        },
+        {
           "title": "AFL",
           "path": "sport/afl"
         },

--- a/json/navigation-conf/au.json
+++ b/json/navigation-conf/au.json
@@ -54,12 +54,12 @@
       "path": "au/sport",
       "sections": [
         {
-          "title": "Australia sport",
-          "path": "sport/australia-sport"
-        },
-        {
           "title": "Euro 2024",
           "path": "football/euro-2024"
+        },
+        {
+          "title": "Australia sport",
+          "path": "sport/australia-sport"
         },
         {
           "title": "AFL",

--- a/json/navigation-conf/europe.json
+++ b/json/navigation-conf/europe.json
@@ -82,6 +82,10 @@
       "path": "sport",
       "sections": [
         {
+          "title": "Euro 2024",
+          "path": "football/euro-2024"
+        },
+        {
           "title": "Football",
           "path": "football"
         },

--- a/json/navigation-conf/international.json
+++ b/json/navigation-conf/international.json
@@ -82,6 +82,10 @@
       "path": "sport",
       "sections": [
         {
+          "title": "Euro 2024",
+          "path": "football/euro-2024"
+        },
+        {
           "title": "Football",
           "path": "football"
         },

--- a/json/navigation-conf/uk.json
+++ b/json/navigation-conf/uk.json
@@ -87,6 +87,10 @@
       "path": "uk/sport",
       "sections": [
         {
+          "title": "Euro 2024",
+          "path": "football/euro-2024"
+        },
+        {
           "title": "Football",
           "path": "football"
         },

--- a/json/navigation-conf/us.json
+++ b/json/navigation-conf/us.json
@@ -68,6 +68,10 @@
       "path": "us/sport",
       "sections": [
         {
+          "title": "Euro 2024",
+          "path": "football/euro-2024"
+        },
+        {
           "title": "Soccer",
           "path": "us/soccer",
           "mobileOverride": "section-front"


### PR DESCRIPTION
add "Euro 2024" to the Sport navigation across all editions

requirements
- should navigate to https://www.theguardian.com/football/euro-2024
- should go in first place on the nav
- to be merged on Wednesday 13 June 2024

**UK**
<img src="https://github.com/guardian/cross-platform-navigation/assets/47318984/bfadac80-d9df-496f-9d0b-6bbbb7ae3221" width="300px" />

**US**
<img src="https://github.com/guardian/cross-platform-navigation/assets/47318984/428c295e-47c9-42cd-91b4-321879e9a7a3" width="300px" />
