### PR TITLE
Remove Euros and add Olympics to the nav

### DIFF
--- a/json/navigation-conf/au.json
+++ b/json/navigation-conf/au.json
@@ -54,8 +54,8 @@
       "path": "au/sport",
       "sections": [
         {
-          "title": "Euro 2024",
-          "path": "football/euro-2024"
+          "title": "Olympics 2024",
+          "path": "sport/olympic-games-2024"
         },
         {
           "title": "Australia sport",

--- a/json/navigation-conf/europe.json
+++ b/json/navigation-conf/europe.json
@@ -82,8 +82,8 @@
       "path": "sport",
       "sections": [
         {
-          "title": "Euro 2024",
-          "path": "football/euro-2024"
+          "title": "Olympics 2024",
+          "path": "sport/olympic-games-2024"
         },
         {
           "title": "Football",

--- a/json/navigation-conf/international.json
+++ b/json/navigation-conf/international.json
@@ -82,8 +82,8 @@
       "path": "sport",
       "sections": [
         {
-          "title": "Euro 2024",
-          "path": "football/euro-2024"
+          "title": "Olympics 2024",
+          "path": "sport/olympic-games-2024"
         },
         {
           "title": "Football",

--- a/json/navigation-conf/uk.json
+++ b/json/navigation-conf/uk.json
@@ -87,8 +87,8 @@
       "path": "uk/sport",
       "sections": [
         {
-          "title": "Euro 2024",
-          "path": "football/euro-2024"
+          "title": "Olympics 2024",
+          "path": "sport/olympic-games-2024"
         },
         {
           "title": "Football",

--- a/json/navigation-conf/us.json
+++ b/json/navigation-conf/us.json
@@ -68,8 +68,8 @@
       "path": "us/sport",
       "sections": [
         {
-          "title": "Euro 2024",
-          "path": "football/euro-2024"
+          "title": "Olympics 2024",
+          "path": "sport/olympic-games-2024"
         },
         {
           "title": "Soccer",


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Replace Euro 2024 with Olympics 2024 in Sports nav
Link: https://www.theguardian.com/sport/olympic-games-2024
Copy: [Olympics 2024](https://www.theguardian.com/sport/olympic-games-2024)
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
| Before | After |
| --- | --- |
| <img width="300px" src="https://github.com/user-attachments/assets/610b6c7a-94ee-44d8-96b1-1ffe88560537" /> |<img width="300px" src="https://github.com/user-attachments/assets/15383cac-5559-4727-9bbe-9df7d0785f84" /> |

