### PR TITLE
Add Olympics 2024 to US main nav

### DIFF
--- a/json/navigation-conf/us.json
+++ b/json/navigation-conf/us.json
@@ -9,12 +9,7 @@
       "title": "US elections 2024",
       "path": "us-news/us-elections-2024",
       "sections": []
-    },
-    {
-      "title": "Donald Trump trials",
-      "path": "us-news/donald-trump-trials",
-      "sections": []
-    },    
+    },   
     {
       "title": "Politics",
       "path": "us-news/us-politics",
@@ -106,6 +101,11 @@
           "path": "sport/golf"
         }
       ]
+    },
+    {
+      "title": "Olympics 2024",
+      "path": "sport/olympic-games-2024",
+      "sections": []
     },
     {
       "title": "Soccer",


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Add Olympics 2024 to US main nav and remove Donald Trump trials
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
| Before | After |
| -- | -- |
| <img src="https://github.com/user-attachments/assets/8ecd8aa1-4dcf-4cf6-a7e7-0b85536af213" width="300px" /> | <img src="https://github.com/user-attachments/assets/dc901c08-eaad-4f5d-8713-3da29b908843" width="300px" /> |