### PR TITLE
Remove olympics from US nav

### DIFF
--- a/json/navigation-conf/us.json
+++ b/json/navigation-conf/us.json
@@ -11,6 +11,11 @@
       "sections": []
     },   
     {
+      "title": "Democratic national convention",
+      "path": "us-news/democratic-national-convention-2024",
+      "sections": []
+    },   
+    {
       "title": "Politics",
       "path": "us-news/us-politics",
       "sections": []
@@ -63,10 +68,6 @@
       "path": "us/sport",
       "sections": [
         {
-          "title": "Olympics 2024",
-          "path": "sport/olympic-games-2024"
-        },
-        {
           "title": "Soccer",
           "path": "us/soccer",
           "mobileOverride": "section-front"
@@ -101,11 +102,6 @@
           "path": "sport/golf"
         }
       ]
-    },
-    {
-      "title": "Olympics 2024",
-      "path": "sport/olympic-games-2024",
-      "sections": []
     },
     {
       "title": "Soccer",


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
CP request

- remove Olympics 2024 from the main nav list 
- add a link for Democratic national convention in third slot, after US elections https://www.theguardian.com/us-news/democratic-national-convention-2024
- Under Sports, remove Olympics 2024 

To add Paralympics on or around 28th August
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## Images
<img src="https://github.com/user-attachments/assets/92e0cb86-f418-4fc4-a289-c021b69ac550" width="300px" />

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
