### PR TITLE
Remove Olympics from nav

### DIFF
--- a/json/navigation-conf/au.json
+++ b/json/navigation-conf/au.json
@@ -54,10 +54,6 @@
       "path": "au/sport",
       "sections": [
         {
-          "title": "Olympics 2024",
-          "path": "sport/olympic-games-2024"
-        },
-        {
           "title": "Australia sport",
           "path": "sport/australia-sport"
         },

--- a/json/navigation-conf/europe.json
+++ b/json/navigation-conf/europe.json
@@ -82,10 +82,6 @@
       "path": "sport",
       "sections": [
         {
-          "title": "Olympics 2024",
-          "path": "sport/olympic-games-2024"
-        },
-        {
           "title": "Football",
           "path": "football"
         },

--- a/json/navigation-conf/international.json
+++ b/json/navigation-conf/international.json
@@ -82,10 +82,6 @@
       "path": "sport",
       "sections": [
         {
-          "title": "Olympics 2024",
-          "path": "sport/olympic-games-2024"
-        },
-        {
           "title": "Football",
           "path": "football"
         },

--- a/json/navigation-conf/uk.json
+++ b/json/navigation-conf/uk.json
@@ -87,10 +87,6 @@
       "path": "uk/sport",
       "sections": [
         {
-          "title": "Olympics 2024",
-          "path": "sport/olympic-games-2024"
-        },
-        {
           "title": "Football",
           "path": "football"
         },


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Remove olympics from nav for all the remaining editions
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## Screenshots
<img src="https://github.com/user-attachments/assets/60beb067-b47b-42e7-bd22-4d622b114678" width="300px" />

