### PR TITLE
Add Paralympics 2024

### DIFF
--- a/json/navigation-conf/au.json
+++ b/json/navigation-conf/au.json
@@ -54,6 +54,10 @@
       "path": "au/sport",
       "sections": [
         {
+          "title": "Paralympics 2024",
+          "path": "sport/paralympic-games-2024"
+        },
+        {
           "title": "Australia sport",
           "path": "sport/australia-sport"
         },

--- a/json/navigation-conf/europe.json
+++ b/json/navigation-conf/europe.json
@@ -82,6 +82,10 @@
       "path": "sport",
       "sections": [
         {
+          "title": "Paralympics 2024",
+          "path": "sport/paralympic-games-2024"
+        },
+        {
           "title": "Football",
           "path": "football"
         },

--- a/json/navigation-conf/international.json
+++ b/json/navigation-conf/international.json
@@ -82,6 +82,10 @@
       "path": "sport",
       "sections": [
         {
+          "title": "Paralympics 2024",
+          "path": "sport/paralympic-games-2024"
+        },
+        {
           "title": "Football",
           "path": "football"
         },

--- a/json/navigation-conf/uk.json
+++ b/json/navigation-conf/uk.json
@@ -87,6 +87,10 @@
       "path": "uk/sport",
       "sections": [
         {
+          "title": "Paralympics 2024",
+          "path": "sport/paralympic-games-2024"
+        },
+        {
           "title": "Football",
           "path": "football"
         },

--- a/json/navigation-conf/us.json
+++ b/json/navigation-conf/us.json
@@ -68,6 +68,10 @@
       "path": "us/sport",
       "sections": [
         {
+          "title": "Paralympics 2024",
+          "path": "sport/paralympic-games-2024"
+        },
+        {
           "title": "Soccer",
           "path": "us/soccer",
           "mobileOverride": "section-front"
@@ -102,6 +106,11 @@
           "path": "sport/golf"
         }
       ]
+    },
+    {
+      "title": "Paralympics 2024",
+      "path": "sport/paralympic-games-2024",
+      "sections": []
     },
     {
       "title": "Soccer",


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Add Paralympics to all editions nav (to be merged close to 26 August)
- In the main and under sports nav for US
- Under Sports in all other regions
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## Images
**UK**
<img src="https://github.com/user-attachments/assets/d630eb25-3b7f-4201-a19a-e49274b81d06" width="300" />
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

**US**
<img src="https://github.com/user-attachments/assets/6d2a808f-a951-4c15-a51c-0b3c7b97bd1e" width="300" />

**Aus**
<img src="https://github.com/user-attachments/assets/547e5dd0-7311-4660-9112-e81cd96e341b" width="300" />

**Europe**
<img src="https://github.com/user-attachments/assets/ec03366f-aae1-45f4-8cc9-b5155b749679" width="300" />

**International**
<img src="https://github.com/user-attachments/assets/6992d16b-8389-4c59-88b8-dec46fa186b0" width="300" />
