### PR TITLE
Support Scala 3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ name:="cross-platform-navigation"
 
 ThisBuild / scalaVersion := "3.3.3"
 
-crossScalaVersions := Seq(scalaVersion.value, "2.13.14", "2.12.20")
+crossScalaVersions := Seq(scalaVersion.value, "2.13.14")
 
 resolvers ++= Resolver.sonatypeOssRepos("releases")
 

--- a/build.sbt
+++ b/build.sbt
@@ -3,9 +3,9 @@ import sbtversionpolicy.withsbtrelease.ReleaseVersion
 
 name:="cross-platform-navigation"
 
-ThisBuild / scalaVersion := "2.13.14"
+ThisBuild / scalaVersion := "3.3.3"
 
-crossScalaVersions := Seq(scalaVersion.value, "2.12.20")
+crossScalaVersions := Seq(scalaVersion.value, "2.13.14", "2.12.20")
 
 resolvers ++= Resolver.sonatypeOssRepos("releases")
 

--- a/src/main/scala/com/gu/navigation/model/NavigationSection.scala
+++ b/src/main/scala/com/gu/navigation/model/NavigationSection.scala
@@ -29,14 +29,14 @@ object NavigationSection  {
       (__ \ "mobileOverride").writeNullable[String] and
       (__ \ "sections").lazyWriteNullable(implicitly[Writes[List[NavigationSection]]]) and
       (__ \ "editionOverride").writeNullable[String]
-    )(unlift(NavigationSection.unapply _))
+    )(unlift((ns: NavigationSection) => Some((ns.title, ns.path, ns.mobileOverride, ns.sections, ns.editionOverride))))
 
   implicit lazy val disNavigationSectionFormat: Format[NavigationSection] = Format(navigationSectionReads, navigationSectionWrites)
 
 }
 
 object Navigation {
-  implicit val jf = Json.format[Navigation]
+  implicit val jf: Format[Navigation] = Json.format[Navigation]
 }
 
 case class Navigation(pillars: List[NavigationSection])


### PR DESCRIPTION
This is prompted by https://github.com/guardian/mobile-apps-api/issues/3198 - we would like to be able to upgrade MAPI to Scala 3. As MAPI depends on https://github.com/guardian/cross-platform-navigation, it's good to have a Scala 3 version of this library.

### `unapply()` has changed in Scala 3

The only tricky part of upgrading `cross-platform-navigation` to Scala 3 is handling the explicit call to the `unapply()` method, which _used_ to return an `Option[(...,...,...)]` with all the parameters used to create the case class - in Scala 3 that's changed:

* https://docs.scala-lang.org/scala3/guides/migration/incompat-other-changes.html#explicit-call-to-unapply
* https://github.com/scala/scala3/issues/2335

The least magical way to cope with the changed `unapply()` method is to manually write out what the unapply method used to produce, and that's what I've done here. Looking at the discussion on the Scala issue, there are other workarounds which are Scala 3-only (and so wouldn't easily work in this project, which cross-compiles with Scala 2):

https://github.com/scala/scala3/issues/2335#issuecomment-758038002 gives us this, which did work for me, but just in Scala 3:
```scala
def doOldUnapply(ns: NavigationSection) = Some(Tuple.fromProductTyped(ns))
```
https://github.com/scala/scala3/issues/2335#issuecomment-1309916758 - this is apparently a general version of the method above, but didn't work for me - complained that `NavigationSection` is not a `Product`, I think?
```scala
def unapply[P <: Product](p: P)(using m: scala.deriving.Mirror.ProductOf[P]): Option[m.MirroredElemTypes] =
  Some(Tuple.fromProductTyped(p))
```