### PR TITLE
Remove democratic national convention from US nav

### DIFF
--- a/json/navigation-conf/us.json
+++ b/json/navigation-conf/us.json
@@ -11,11 +11,6 @@
       "sections": []
     },   
     {
-      "title": "Democratic national convention",
-      "path": "us-news/democratic-national-convention-2024",
-      "sections": []
-    },   
-    {
       "title": "Politics",
       "path": "us-news/us-politics",
       "sections": []


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

As per editorials' request, this pull request removes the menu item "Democratic national convention" from the US navigation menu. 

## How to test
The updated menu was tested on CODE.

| Before | After |
| --- | --- |
| <img width="300px" src="https://github.com/user-attachments/assets/8d0b3a15-0198-4ae1-8c23-0261d48706fe" /> | <img width="300px" src="https://github.com/user-attachments/assets/e08ff547-eac1-4862-8883-c9e950cedbcb" />