### PR TITLE
Add Australia health news to AU nav

### DIFF
--- a/json/navigation-conf/au.json
+++ b/json/navigation-conf/au.json
@@ -268,6 +268,11 @@
       ]
     },
     {
+      "title": "Health",
+      "path": "australia-news/health",
+      "sections": []
+    },
+    {
       "title": "Science",
       "path": "science",
       "sections": []


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

As per editorials request, this pull request adds a new item named "Health" pointing to the Australia health news front (`australia-news/health`) to AU nav between "Environment" and "Science".

The change was validated on `CODE`.

| Before | After |
| --- | --- |
| <img width="360px" src="https://github.com/user-attachments/assets/90df213d-9fa9-47d6-b865-d6c463efdf68" /> | <img width="360px" src="https://github.com/user-attachments/assets/0fe22505-29ed-4720-b7ca-2cd41a9490d5" /> |

This "Health" item takes us here:
<img width="360px" src="https://github.com/user-attachments/assets/8c1bae87-35e2-4cee-abd8-99273ff488f6" />