### PR TITLE
Add The Filter to UK sub-nav

### DIFF
--- a/json/navigation-conf/uk.json
+++ b/json/navigation-conf/uk.json
@@ -247,7 +247,7 @@
         },
         {
           "title": "The Filter",
-          "path": "thefilter"
+          "path": "uk/thefilter"
         },
         {
           "title": "Health & fitness",

--- a/json/navigation-conf/uk.json
+++ b/json/navigation-conf/uk.json
@@ -246,6 +246,10 @@
           "path": "food"
         },
         {
+          "title": "The Filter",
+          "path": "thefilter"
+        },
+        {
           "title": "Health & fitness",
           "path": "lifeandstyle/health-and-wellbeing"
         },


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Add The Filter to the UK sub-nav which should navigate to the `/uk/thefilter` front.
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
The content/front is not published yet so I've tested by setting up a CODE front with `uk/thefilter`.
Once this front goes live, I'll test again before merging.

| iOS | Android |
| -- | -- |
<img src="https://github.com/user-attachments/assets/3c86a12a-b4a2-4a45-9a73-1b8b1ba1600b" width="200px" />| <img src="https://github.com/user-attachments/assets/9ef15c9a-8adb-47b7-947a-8d535e09b5a1" width="200px" />
