### PR TITLE
Enable riffraff deployment to CODE

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,10 +84,8 @@ Deploying the project via riff-raff will upload the latest editionalised json fi
 #### Testing your changes on the app
 
 1. Deploy the branch to CODE with riff-raff (`Mobile::cross-platform-navigation`)
-2. Redeploy the CODE mobile-fronts with riffraff (`Mobile::mobile-fronts`): mobile-fronts caches a copy of the json so redeploy any branch to invalidate
-   the cache.
-3. **Configure the Debug App**: On the debug app, go into the debug settings and get the app to use CODE mapi and clear your cache.
-4. **Verify your changes**: You should see the nav bar has changed. Make sure you're on the correct edition!
+2. **Configure the Debug App**: On the debug app, go into the debug settings and get the app to use CODE mapi and clear your cache.
+3. **Verify your changes**: You should see the nav bar has changed (it may take a few minutes to update due to the Fastly cache). Make sure you're on the correct edition!
 
 Having done the above steps you should feel confident to merge your changes.
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ You can den do something like
 
 #### Updating the navigation
 
-The directory [json](https://github.com/guardian/cross-platform-navigation/tree/nb-MSS-166-create-navigation/json) contains the definition for each of the guardians 4 editions as json files. Altering these files and releasing the project via riff-raff causes the updated files to be provisioned to s3. Your application can then retrieve (and cache) the json as you wish and use it at described above 
+The directory [json](https://github.com/guardian/cross-platform-navigation/tree/nb-MSS-166-create-navigation/json) contains the definition for each of the guardians 4 editions as json files. Altering these files and releasing the project via riff-raff causes the updated files to be provisioned to s3. Your application can then retrieve (and cache) the json as you wish and use it at described above
 
 #### Json Format
 
@@ -51,7 +51,7 @@ Here, there are only two pillars, with a cut down set of sections to indicate ho
           ]
         }
       ]
-    },     
+    },
     {
       "title": "sport",
       "path": "/sport",
@@ -77,20 +77,17 @@ Here, there are only two pillars, with a cut down set of sections to indicate ho
 
 #### Publishing and Deploying
 
-Update the scala functionality and publish to maven, making sure you update the version and the changelog. 
+Update the scala functionality and publish to maven, making sure you update the version and the changelog.
 
-Deploying the project via riff-raff will upload the latest editionalised json files to s3, via teamcity. This process checks the validity of the json in order to build successfully
+Deploying the project via riff-raff will upload the latest editionalised json files to s3. The CI (Github Actions) tests check the validity of the json in order to build successfully
 
 #### Testing your changes on the app
 
-You won't be able to deploy a change to the CODE stage of cross-platform-navigation as riffraff will block you from doing so, warning that any change deployed to CODE will actually be deployed to production. Therefore, you need to
-
-1. **Access the Mobile Account in AWS**: Go to [janus](https://janus.gutools.co.uk/) and navigate to the mobile account.
-2. **Locate the S3 Bucket**: Find the S3 bucket named "mobile-navigation-dist". 
-3. **Replace JSON File**: In the "CODE" folder, replace the relevant JSON file with the version containing your local changes.
-4. **Redeploy mobile-fronts in riffraff**: Redeploy the mobile-fronts service in riffraff to CODE (as mobile-fronts caches a copy of the json).
-5. **Configure the Debug App**: On the debug app, go into the debug settings and get the app to use CODE mapi and clear your cache.
-6. **Verify your changes**: You should see the nav bar has changed. Make sure you're on the correct edition! 
+1. Deploy the branch to CODE with riff-raff (`Mobile::cross-platform-navigation`)
+2. Redeploy the CODE mobile-fronts with riffraff (`Mobile::mobile-fronts`): mobile-fronts caches a copy of the json so redeploy any branch to invalidate
+   the cache.
+3. **Configure the Debug App**: On the debug app, go into the debug settings and get the app to use CODE mapi and clear your cache.
+4. **Verify your changes**: You should see the nav bar has changed. Make sure you're on the correct edition!
 
 Having done the above steps you should feel confident to merge your changes.
 

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -12,4 +12,5 @@ deployments:
       publicReadAcl: false
       prefixPackage: false
       prefixStack: false
+      prefixStage: true
       bucketSsmLookup: true

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -2,6 +2,7 @@ stacks: [mobile]
 regions: [eu-west-1]
 allowedStages:
   - CODE
+  - PROD
 deployments:
   json:
     type: aws-s3

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -1,10 +1,15 @@
 stacks: [mobile]
 regions: [eu-west-1]
-
+allowedStages:
+  - CODE
+  - PROD
 deployments:
   json:
     type: aws-s3
     parameters:
+      bucketSsmKeyStageParam:
+        CODE: /CODE/account/services/artifact.bucket.nav
+        PROD: /account/services/artifact.bucket.nav
       cacheControl: max-age=600
       publicReadAcl: false
       prefixPackage: false

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -13,4 +13,4 @@ deployments:
       prefixStack: false
       prefixStage: true
       bucketSsmLookup: true
-      bucketSsmKey: /account/services/artifact.bucket.nav.test
+      bucketSsmKey: /account/services/artifact.bucket.nav

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -6,11 +6,10 @@ deployments:
   json:
     type: aws-s3
     parameters:
-      bucketSsmKeyStageParam:
-        CODE: /account/services/artifact.bucket.nav.test
       cacheControl: max-age=600
       publicReadAcl: false
       prefixPackage: false
       prefixStack: false
       prefixStage: true
       bucketSsmLookup: true
+      bucketSsmKey: /account/services/artifact.bucket.nav.test

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -2,17 +2,14 @@ stacks: [mobile]
 regions: [eu-west-1]
 allowedStages:
   - CODE
-  - PROD
 deployments:
   json:
     type: aws-s3
     parameters:
       bucketSsmKeyStageParam:
-        CODE: /CODE/account/services/artifact.bucket.nav
-        PROD: /account/services/artifact.bucket.nav
+        CODE: /account/services/artifact.bucket.nav.test
       cacheControl: max-age=600
       publicReadAcl: false
       prefixPackage: false
       prefixStack: false
       bucketSsmLookup: true
-      bucketSsmKey: /account/services/artifact.bucket.nav


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Until now we have been testing nav changes manually by uploading the files into the S3 `/CODE` folder directly on the AWS console without using RiffRaff. But I have tested that we can actually use RiffRaff to deploy to the CODE bucket. 

I suspect this has always been possible because [RiffRaff pre-fixes the target stage to the bucket key](https://github.com/guardian/riff-raff/blob/30e98413b89bf29692ccf1af6f003f53f5fb093b/magenta-lib/src/main/scala/magenta/deployment_type/S3.scala#L92-L93) but it seems we were (unintentionally and unfortunately) misled by the outdated deployment restriction message on riffraff.

The following are more of cosmetic changes.

Changes:
- set `allowedStages` to CODE and PROD to constrain available stages on RiffRaff
- set `prefixStage` to true (default value but I've added it explicitly just to make it clear)
- remove CODE deploy restrictions on RiffRaff
- update readme to use riffraff for deploying to CODE
 
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
I've tested by:
1. Setting up a test S3 bucket (`navigation-dist-test`) and deploying to [CODE](https://riffraff.gutools.co.uk/deployment/view/7323269f-b1fa-4751-a99b-a0a488aaed2d?verbose=1) and [PROD](https://riffraff.gutools.co.uk/deployment/view/d373395b-2af4-46ea-9dd6-acb871eec1ea) using the current RiffRaff config pointing to the test bucket
2. Checking that the json files are correctly uploaded to the respective CODE and PROD directories in the test bucket
3. Deploying to our actual nav bucket [on CODE ](https://riffraff.gutools.co.uk/deployment/view/7b90a497-d3c8-4986-ade6-8468a77558fd) and checking the changes are deployed to CODE and not to PROD