### PR TITLE
add WNBA (US) and update support us link (all editions)

### DIFF
--- a/json/navigation-conf/au.json
+++ b/json/navigation-conf/au.json
@@ -351,7 +351,7 @@
     },    
     {
       "title": "Support us",
-      "path": "membership",
+      "path": "insidetheguardian",
       "sections": []
     },
     {

--- a/json/navigation-conf/europe.json
+++ b/json/navigation-conf/europe.json
@@ -435,7 +435,7 @@
     },
     {
       "title": "Support us",
-      "path": "membership",
+      "path": "insidetheguardian",
       "sections": []
     },
     {

--- a/json/navigation-conf/international.json
+++ b/json/navigation-conf/international.json
@@ -435,7 +435,7 @@
     },
     {
       "title": "Support us",
-      "path": "membership",
+      "path": "insidetheguardian",
       "sections": []
     },
     {

--- a/json/navigation-conf/uk.json
+++ b/json/navigation-conf/uk.json
@@ -436,7 +436,7 @@
     },
     {
       "title": "Support us",
-      "path": "membership",
+      "path": "insidetheguardian",
       "sections": []
     },
     {

--- a/json/navigation-conf/us.json
+++ b/json/navigation-conf/us.json
@@ -85,6 +85,10 @@
           "path": "sport/nba"
         },
         {
+          "title": "WNBA",
+          "path": "sport/wnba"
+        },
+        {
           "title": "NHL",
           "path": "sport/nhl"
         },
@@ -361,7 +365,7 @@
     },
     {
       "title": "Support us",
-      "path": "membership",
+      "path": "insidetheguardian",
       "sections": []
     },
     {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
CP requested
- change "Support us" to this link on all editions to https://www.theguardian.com/insidetheguardian for all editions
- add WNBA below NBA for US


<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
Tested on CODE
- [x] US
    - [x] WNBA
    - [x] support us
- [x] UK
- [x] AU
- [x] Europe
- [x] International



## Images
| Support Us | WNBA (US) |
|------------|-----------|
| <img src="https://github.com/user-attachments/assets/1cec3e9c-6473-4f19-82f0-56db38a390cc" width="200px" /> | <img src="https://github.com/user-attachments/assets/3abb9dd3-aaae-485a-bcbf-b9af31e68ae2" width="200px" /> |
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
