### PR TITLE
Add US elections 2024

### DIFF
--- a/json/navigation-conf/europe.json
+++ b/json/navigation-conf/europe.json
@@ -40,6 +40,11 @@
       ]
     },
     {
+      "title": "US elections 2024",
+      "path": "us-news/us-elections-2024",
+      "sections": []
+    },
+    {
       "title": "World",
       "path": "world",
       "sections": [
@@ -346,7 +351,7 @@
       "title": "Obituaries",
       "path": "tone/obituaries",
       "sections": []
-    },    
+    },
     {
       "title": "Video",
       "path": "video",
@@ -427,7 +432,7 @@
       "title": "Live events",
       "path": "guardian-live-events",
       "sections": []
-    },    
+    },
     {
       "title": "The Observer",
       "path": "observer",

--- a/json/navigation-conf/international.json
+++ b/json/navigation-conf/international.json
@@ -40,6 +40,11 @@
       ]
     },
     {
+      "title": "US elections 2024",
+      "path": "us-news/us-elections-2024",
+      "sections": []
+    },
+    {
       "title": "World",
       "path": "world",
       "sections": [
@@ -346,7 +351,7 @@
       "title": "Obituaries",
       "path": "tone/obituaries",
       "sections": []
-    },    
+    },
     {
       "title": "Video",
       "path": "video",
@@ -427,7 +432,7 @@
       "title": "Live events",
       "path": "guardian-live-events",
       "sections": []
-    },    
+    },
     {
       "title": "The Observer",
       "path": "observer",

--- a/json/navigation-conf/uk.json
+++ b/json/navigation-conf/uk.json
@@ -40,6 +40,11 @@
       ]
     },
     {
+      "title": "US elections 2024",
+      "path": "us-news/us-elections-2024",
+      "sections": []
+    },
+    {
       "title": "Politics",
       "path": "politics",
       "sections": []
@@ -351,7 +356,7 @@
     {
       "title": "Society",
       "path": "society",
-      "sections" : []
+      "sections": []
     },
     {
       "title": "Media",
@@ -362,7 +367,7 @@
       "title": "Obituaries",
       "path": "tone/obituaries",
       "sections": []
-    },    
+    },
     {
       "title": "Video",
       "path": "video",


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

As per editorial request, this pull request adds the nav item `US elections 2024` to the nav menu of UK, Europe and International editions.

## How to test

The updated menu was validated on `CODE`.  Screenshots are pasted below:

| UK | Europe | International |
| --- | --- | --- |
| <img width="240px" src="https://github.com/user-attachments/assets/828a3aa5-cf2b-4513-a359-54d3bfacf989" /> | <img width="240px" src="https://github.com/user-attachments/assets/07ad011d-790e-4d19-a227-a0ebdf37473b" /> | <img width="240px" src="https://github.com/user-attachments/assets/b7df156e-f2d8-4aa7-a025-8b3d49f9fc28" /> |

The nav item takes users to the front on US elections 2024:
<img width="240px" src="https://github.com/user-attachments/assets/4600e677-6c56-4727-832d-b54d3618ff31" />