### PR TITLE
Update US Politics and add Ukraine

### DIFF
--- a/json/navigation-conf/au.json
+++ b/json/navigation-conf/au.json
@@ -36,6 +36,10 @@
         {
           "title": "Middle East",
           "path": "world/middleeast"
+        },
+        {
+          "title": "Ukraine",
+          "path": "world/ukraine"
         }
       ]
     },
@@ -348,7 +352,7 @@
       "title": "Obituaries",
       "path": "tone/obituaries",
       "sections": []
-    },    
+    },
     {
       "title": "Support us",
       "path": "insidetheguardian",

--- a/json/navigation-conf/europe.json
+++ b/json/navigation-conf/europe.json
@@ -40,8 +40,8 @@
       ]
     },
     {
-      "title": "US elections 2024",
-      "path": "us-news/us-elections-2024",
+      "title": "US politics",
+      "path": "us-news/us-politics",
       "sections": []
     },
     {
@@ -75,6 +75,10 @@
         {
           "title": "Middle East",
           "path": "world/middleeast"
+        },
+        {
+          "title": "Ukraine",
+          "path": "world/ukraine"
         },
         {
           "title": "Development",

--- a/json/navigation-conf/international.json
+++ b/json/navigation-conf/international.json
@@ -40,8 +40,8 @@
       ]
     },
     {
-      "title": "US elections 2024",
-      "path": "us-news/us-elections-2024",
+      "title": "US politics",
+      "path": "us-news/us-politics",
       "sections": []
     },
     {
@@ -75,6 +75,10 @@
         {
           "title": "Middle East",
           "path": "world/middleeast"
+        },
+        {
+          "title": "Ukraine",
+          "path": "world/ukraine"
         },
         {
           "title": "Development",

--- a/json/navigation-conf/uk.json
+++ b/json/navigation-conf/uk.json
@@ -40,8 +40,8 @@
       ]
     },
     {
-      "title": "US elections 2024",
-      "path": "us-news/us-elections-2024",
+      "title": "US politics",
+      "path": "us-news/us-politics",
       "sections": []
     },
     {
@@ -80,6 +80,10 @@
         {
           "title": "Middle East",
           "path": "world/middleeast"
+        },
+        {
+          "title": "Ukraine",
+          "path": "world/ukraine"
         },
         {
           "title": "Development",

--- a/json/navigation-conf/us.json
+++ b/json/navigation-conf/us.json
@@ -6,10 +6,10 @@
       "sections": []
     },
     {
-      "title": "US elections 2024",
-      "path": "us-news/us-elections-2024",
+      "title": "US politics",
+      "path": "us-news/us-politics",
       "sections": []
-    },   
+    },
     {
       "title": "Politics",
       "path": "us-news/us-politics",
@@ -38,6 +38,10 @@
         {
           "title": "Middle East",
           "path": "world/middleeast"
+        },
+        {
+          "title": "Ukraine",
+          "path": "world/ukraine"
         },
         {
           "title": "Africa",
@@ -281,7 +285,7 @@
       "title": "Obituaries",
       "path": "tone/obituaries",
       "sections": []
-    },    
+    },
     {
       "title": "Video",
       "path": "video",


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

- [ ] 'US elections 2024' to 'US politics' https://www.theguardian.com/us-news/us-politics (UK, Europe, International, US editions)
- [ ] Add Ukraine under where Middle East sits in the World subnav

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
Tested on CODE with iOS simulator

## Images

