### PR TITLE
remove duplicate us politics from us nav (DO NOT MERGE)

### DIFF
--- a/json/navigation-conf/us.json
+++ b/json/navigation-conf/us.json
@@ -6,11 +6,6 @@
       "sections": []
     },
     {
-      "title": "US politics",
-      "path": "us-news/us-politics",
-      "sections": []
-    },
-    {
       "title": "Politics",
       "path": "us-news/us-politics",
       "sections": []


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
The duplicate US politics id was crashing the android app so removing it.
As a next step we should add a test to check there are no duplicate entries to catch cases like this.

Do not merge until Android devs are done with testing a related change on their end

## How to test
Deployed to code and tested with android emulator.
Navigating to Politics in US edition no longer crashes.
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## Images
![image](https://github.com/user-attachments/assets/cac5569c-7a4c-4fad-bb61-200cade37e86)

