### PR TITLE
add climate crisis to US nav

### DIFF
--- a/json/navigation-conf/us.json
+++ b/json/navigation-conf/us.json
@@ -266,6 +266,11 @@
       ]
     },
     {
+      "title": "Climate crisis",
+      "path": "environment/climate-crisis",
+      "sections": []
+    },
+    {
       "title": "Science",
       "path": "science",
       "sections": []


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
add Climate crisis after Environment for US edition only

## Images
