### PR TITLE
Add columnist subnav to uk opinion nav

### DIFF
--- a/json/navigation-conf/uk.json
+++ b/json/navigation-conf/uk.json
@@ -149,7 +149,12 @@
     {
       "title": "Opinion",
       "path": "uk/commentisfree",
-      "sections": []
+      "sections": [
+        {
+          "title": "Columnists",
+          "path": "uk/columnists"
+        }
+      ]
     },
     {
       "title": "Culture",


### PR DESCRIPTION
Add columnist to UK opinion nav. This will fulfill an editorial request. 