### PR TITLE
Add world cup 2026 to football nav

### DIFF
--- a/json/navigation-conf/au.json
+++ b/json/navigation-conf/au.json
@@ -103,7 +103,12 @@
     {
       "title": "Football",
       "path": "football",
-      "sections": []
+      "sections": [
+        {
+          "title": "World Cup 2026",
+          "path": "football/world-cup-2026"
+        }
+      ]
     },
     {
       "title": "Tech",

--- a/json/navigation-conf/europe.json
+++ b/json/navigation-conf/europe.json
@@ -139,8 +139,12 @@
     {
       "title": "Football",
       "path": "football",
-
-      "sections": []
+      "sections": [
+        {
+          "title": "World Cup 2026",
+          "path": "football/world-cup-2026"
+        }
+      ]
     },
     {
       "title": "Opinion",

--- a/json/navigation-conf/international.json
+++ b/json/navigation-conf/international.json
@@ -139,8 +139,12 @@
     {
       "title": "Football",
       "path": "football",
-
-      "sections": []
+      "sections": [
+        {
+          "title": "World Cup 2026",
+          "path": "football/world-cup-2026"
+        }
+      ]
     },
     {
       "title": "Opinion",

--- a/json/navigation-conf/uk.json
+++ b/json/navigation-conf/uk.json
@@ -144,7 +144,12 @@
     {
       "title": "Football",
       "path": "football",
-      "sections": []
+      "sections": [
+        {
+          "title": "World Cup 2026",
+          "path": "football/world-cup-2026"
+        }
+      ]
     },
     {
       "title": "Opinion",

--- a/json/navigation-conf/us.json
+++ b/json/navigation-conf/us.json
@@ -110,7 +110,12 @@
       "title": "Soccer",
       "path": "us/soccer",
       "mobileOverride": "section-front",
-      "sections": []
+      "sections": [
+        {
+          "title": "World Cup 2026",
+          "path": "football/world-cup-2026"
+        }
+      ]
     },
     {
       "title": "Tech",


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Adds world cup 2026 to football nav. 

## How has this change been tested?

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
